### PR TITLE
Add PWC feature flag support

### DIFF
--- a/config.php
+++ b/config.php
@@ -69,6 +69,11 @@ $wc_pp_feature_flags = [
 		'filter'  => 'woocommerce.feature-flags.woocommerce_paypal_payments.contact_module_enabled',
 		'default' => static fn() => getenv( 'PCP_CONTACT_MODULE_ENABLED' ) === '1',
 	],
+	'wcpp/pwc_enabled'              => [
+		'label'   => 'Pay with Crypto',
+		'filter'  => 'woocommerce.feature-flags.woocommerce_paypal_payments.pwc_enabled',
+		'default' => static fn() => getenv( 'PCP_PWC_ENABLED' ) === '1',
+	],
 
 	// Plugin settings.
 	'wcpp/logging'                       => [


### PR DESCRIPTION
### Description

This PR will add support for the Pay with Crypto feature flag.

Controlled via `woocommerce.feature-flags.woocommerce_paypal_payments.pwc_enabled` filter. Defaults to checking `PCP_PWC_ENABLED` environment variable.

### Screenshot

<img width="1068" height="750" alt="Plugins_‹_Network_Admin__WooCommerce_PayPal_Payments_Sites_—_WordPress" src="https://github.com/user-attachments/assets/489673ff-7e5a-4cb8-8931-345a865d6533" />
